### PR TITLE
extended range of reference note selection

### DIFF
--- a/tuner.lua
+++ b/tuner.lua
@@ -3,8 +3,8 @@
 -- llllllll.co/t/tuner
 --
 -- Responds to audio input.
---
--- E3 : Reference note
+-- E2 : Reference note
+-- E3 : Reference volume
 --
 
 local ControlSpec = require "controlspec"
@@ -18,6 +18,8 @@ local screen_dirty = true
 
 local current_freq = -1
 local last_freq = -1
+
+NOTE_NAMES = {"A0", "A#0", "B0", "C1", "C#1", "D1", "D#1", "E1", "F1", "F#1", "G1", "G#1", "A1", "A#1", "B1", "C2", "C#2", "D2", "D#2", "E2", "F2", "F#2", "G2", "G#2", "A2", "A#2", "B2", "C3", "C#3", "D3", "D#3", "E3", "F3", "F#3", "G3", "G#3", "A3", "A#3", "B3", "C4", "C#4", "D4", "D#4", "E4", "F4", "F#4", "G4", "G#4", "A4", "A#4", "B4", "C5", "C#5", "D5", "D#5", "E5", "F5", "F#5", "G5", "G#5", "A5", "A#5", "B5", "C6", "C#6", "D6", "D#6", "E6", "F6", "F#6", "G6", "G#6", "A6", "A#6", "B6", "C7", "C#7", "D7", "D#7", "E7", "F7", "F#7", "G7", "G#7", "A7", "A#7", "B7", "C8"}
 
 
 -- Encoder input
@@ -56,8 +58,8 @@ function init()
   -- Add params
   
   params:add{type = "option", id = "in_channel", name = "In Channel", options = {"Left", "Right"}}
-  params:add{type = "option", id = "note", name = "Note", options = MusicUtil.NOTE_NAMES, default = 10, action = function(value)
-    engine.hz(MusicUtil.note_num_to_freq(59 + value))
+  params:add{type = "option", id = "note", name = "Note", options = NOTE_NAMES, default = 37, action = function(value)
+    engine.hz(MusicUtil.note_num_to_freq(32 + value))
     screen_dirty = true
   end}
   params:add{type = "control", id = "note_vol", name = "Note Volume", controlspec = ControlSpec.UNIPOLAR, action = function(value)
@@ -160,3 +162,4 @@ function redraw()
   
   screen.update()
 end
+


### PR DESCRIPTION
another change that may only be useful for me :
- extended range of reference note selection from (C3 - B3) to (A0 - C8) aka 88 keys  (helpful when tuning acoustic instruments, etc)
(I tried to find a cleaner way to do this using what's within the MusicUtil library, but this was my hack solution)

- also tweaked script selection info screen to include E2 'reference note' functionality and changed E3 description from reference note to 'reference volume'